### PR TITLE
chore: zenn-markdown-html to 0.1.148

### DIFF
--- a/plugins/zenn-renderer/deps.ts
+++ b/plugins/zenn-renderer/deps.ts
@@ -14,5 +14,5 @@ export {
 export type { Parser } from "https://deno.land/std@0.191.0/encoding/front_matter/mod.ts";
 export { parse as parseYAML } from "https://deno.land/std@0.191.0/yaml/parse.ts";
 
-import zenn from "npm:zenn-markdown-html@0.1.134";
+import zenn from "npm:zenn-markdown-html@0.1.148";
 export const markdownToHtml = zenn.default;


### PR DESCRIPTION
リンクプレビューが開かない件で、内部実装が変更されたとのこと
https://github.com/zenn-dev/zenn-editor/issues/437